### PR TITLE
Add hamlit:erb2haml rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Hamlit-rails
 [![Build Status](https://travis-ci.org/mfung/hamlit-rails.svg)](https://travis-ci.org/mfung/hamlit-rails) [![Gem Version](https://badge.fury.io/rb/hamlit-rails.svg)](http://badge.fury.io/rb/hamlit-rails) [![Code Climate](https://codeclimate.com/github/mfung/hamlit-rails/badges/gpa.svg)](https://codeclimate.com/github/mfung/hamlit-rails) [![Test Coverage](https://codeclimate.com/github/mfung/hamlit-rails/badges/coverage.svg)](https://codeclimate.com/github/mfung/hamlit-rails/coverage)
 
 Provides hamlit generators for Rails 4. It also enables hamlit as the templating
-engine.
+engine and "hamlit:html2haml" rake task that converts erb files to haml.
 
 ## Installation
 

--- a/hamlit-rails.gemspec
+++ b/hamlit-rails.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "railties", ">= 4.0.1"
 
   spec.add_development_dependency "bundler", "~> 1.9"
+  spec.add_development_dependency "html2haml", ">= 2.0.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rails", ">= 4.0.1"
   spec.add_development_dependency "appraisal", "~> 1.0"

--- a/lib/hamlit-rails.rb
+++ b/lib/hamlit-rails.rb
@@ -48,6 +48,10 @@ module Haml
           end
         end
       end
+
+      rake_tasks do
+        load 'hamlit-rails/erb2haml.rake'
+      end
     end
   end
 end

--- a/lib/hamlit-rails/erb2haml.rake
+++ b/lib/hamlit-rails/erb2haml.rake
@@ -1,0 +1,69 @@
+namespace :hamlit do
+  desc 'Convert erb to haml in app/views'
+  task :erb2haml do
+    begin
+      gem 'html2haml'
+    rescue LoadError
+      puts "html2haml gem is not part of the bundle."
+      puts "`rake hamlit:erb2haml` requires html2haml gem to convert erb files."
+      puts
+      puts "Please add html2haml gem temporarily and run `rake hamlit:erb2haml` again."
+      puts "(You can remove html2haml gem after the conversion.)"
+      exit 1
+    end
+
+    erb_files = Dir.glob('app/views/**/*.erb').select(&File.method(:file?))
+    if erb_files.empty?
+      puts 'No .erb files found. Skipping.'
+      return
+    end
+
+    haml_files_in_erb = Dir.glob('app/views/**/*.haml').select(&File.method(:file?)).map do |name|
+      name.sub(/\.haml\z/, '.erb')
+    end
+    existing_files = erb_files.select(&haml_files_in_erb.method(:include?))
+
+    if existing_files.any?
+      puts 'Some of your .erb files seem to have .haml equivalents:'
+      existing_files.map { |f| puts "  #{f}" }
+      puts
+
+      begin
+        print 'Do you want to overwrite them? (y/n): '
+        answer = STDIN.gets.strip.downcase[0]
+      end until ['y', 'n'].include?(answer)
+
+      if answer == 'n'
+        if (erb_files - existing_files).empty?
+          puts 'No .erb files to convert. Skipping.'
+          return
+        end
+      else
+        existing_files.each { |file| File.delete(file.sub(/\.erb\z/, '.haml')) }
+      end
+    end
+    puts
+
+    erb_files.each do |file|
+      puts "Generating .haml for #{file}..."
+      unless system("html2haml #{file} #{file.sub(/\.erb\z/, '.haml')}")
+        abort "Failed to execute `html2haml #{file} #{file.sub(/\.erb\z/, '.haml')}`!"
+      end
+    end
+    puts
+
+    begin
+      print 'Do you want to delete original .erb files? (y/n): '
+      answer = STDIN.gets.strip.downcase[0]
+    end until ['y', 'n'].include?(answer)
+
+    if answer == 'y'
+      puts 'Deleting original .erb files...'
+      File.delete(*erb_files)
+      erb_files.each { |file| puts "  #{file}" }
+    end
+    puts
+
+    puts 'Finished to convert erb files.'
+  end
+end


### PR DESCRIPTION
I saw a person who chose not hamlit-rails but haml-rails due to the lack of `rake haml:erb2haml` task. So I added `rake hamlit:erb2haml` command to provide the feature.

I agree that hamlit-rails gem should not have dependency for html2haml gem since it depends on haml gem. Thus I didn't add html2haml as runtime dependency and suggested temporarily adding html2haml gem in Gemfile.

@mfung What do you think?
