### PR TITLE
Fix rails 6 error `Rails::SourceAnnotationExtractor is not a class/module (TypeError)`.

### DIFF
--- a/lib/hamlit-rails.rb
+++ b/lib/hamlit-rails.rb
@@ -43,7 +43,13 @@ module Haml
       # provided directly by railties 3.2..4.1 but was dropped in 4.2.
       if Gem::Requirement.new(">= 4.2").satisfied_by?(Gem::Version.new(::Rails.version))
         initializer 'hamlit_rails.configure_source_annotation' do
-          SourceAnnotationExtractor::Annotation.register_extensions('haml') do |tag|
+          if ::Rails.version.to_s >= '6.0'
+            annotation_class = ::Rails::SourceAnnotationExtractor::Annotation
+          else
+            annotation_class = SourceAnnotationExtractor::Annotation
+          end
+
+          annotation_class.register_extensions('haml') do |tag|
             /\s*-#\s*(#{tag}):?\s*(.*)/
           end
         end


### PR DESCRIPTION
I got error when start rails(6.0.0.beta1) server:

```
/path/to/gems/hamlit-rails-0.2.0/lib/hamlit-rails.rb:46:in `block in <class:Railtie>’: Rails::SourceAnnotationExtractor is not a class/module (TypeError): Rails::SourceAnnotationExtractor is not a class/module (TypeError)
```

`SourceAnnotationExtractor::Annotation` moved under Rails module, (ref: https://github.com/rails/rails/commit/0ec23effa74e8e9da6ebb14afbd335bea470ab3e)
so switch class depending on rails version.