### PR TITLE
Use bundle add instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,11 @@ engine and "hamlit:erb2haml" rake task that converts erb files to haml.
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Run:
 
-```ruby
-gem 'hamlit-rails'
+```sh
+bundle add hamlit-rails
 ```
-
-And then execute:
-
-    $ bundle
 
 Or install it yourself as:
 


### PR DESCRIPTION
As per https://github.com/rubygems/rubygems/pull/5337, we can simplify the steps of adding a gem.